### PR TITLE
Add isReadOnly property to Calendar object

### DIFF
--- a/lib/src/model/calendar.dart
+++ b/lib/src/model/calendar.dart
@@ -5,14 +5,16 @@ class Calendar {
   String? name;
   String? accountName;
   String? ownerName;
+  bool? isReadOnly;
 
-  Calendar({required this.id, this.name, this.accountName, this.ownerName});
+  Calendar({required this.id, this.name, this.accountName, this.ownerName, this.isReadOnly});
 
   Calendar.fromJson(Map<String, dynamic> data) {
     this.id = data["id"];
     this.name = data["name"];
     this.accountName = data["accountName"];
     this.ownerName = data["ownerName"];
+    this.isReadOnly = data["isReadOnly"];
   }
 
   Map<String, dynamic> toJson() {
@@ -21,6 +23,7 @@ class Calendar {
     data["name"] = this.name;
     data["accountName"] = this.accountName;
     data["ownerName"] = this.ownerName;
+    data["isReadOnly"] = this.isReadOnly;
     return data;
   }
 }


### PR DESCRIPTION
This adds an `isReadOnly` field to Calendar so that we can get only the calendars that are writable.

It is available in the iOS plugin.

<img width="438" alt="Screen Shot 2021-10-27 at 23 23 12" src="https://user-images.githubusercontent.com/55731230/139185600-64f44966-6bd0-4126-8a64-46ea99de5fa1.png">
