### PR TITLE
FLTR-6108 Android: getCalendars() returns incorrect accountName, ownerName and isReadOnly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,38 @@
+## 2.0.2
+
+* Fixed: [Android] `getCalendars()` returns incorrect accountName, ownerName and isReadOnly
+
 ## 2.0.1
+
 * Supporting the new Android plugins APIs. Ref: https://flutter.dev/docs/development/packages-and-plugins/plugin-api-migration
 
 ## 2.0.0
+
 * Add Attendee field support on the Event both iOS and Android
+
 ## 1.0.9
+
 * Add Attendee field [Read-only] support in iOS and Android
+
 ## 1.0.8
+
 * Add URL field on the Event (specially for iOS)
 
 ## 1.0.7
+
 * Implemented a way to filter the events by Week, Month and given dates
 
 ## 1.0.6
+
 * Fixed the Android release mode issue
 * Added isAllDay flag in event as suggested by @sageata
 
 ## 1.0.5
+
 * Added Null Safety support
 
 ## 1.0.4
+
 * Added the required values to avoid unnecessary errors
 
 ## 1.0.3

--- a/android/src/main/java/com/fantastic/manage_calendar_events/CalendarOperations.java
+++ b/android/src/main/java/com/fantastic/manage_calendar_events/CalendarOperations.java
@@ -104,7 +104,20 @@ public class CalendarOperations {
                         .getString(cur.getColumnIndex(Calendars.ACCOUNT_NAME));
                 String ownerName = cur
                         .getString(cur.getColumnIndex(Calendars.OWNER_ACCOUNT));
-                Calendar calendar = new Calendar(calenderId, displayName, accountName, ownerName);
+                final int accessLevel = cur.getInt(cur.getColumnIndex(Calendars.CALENDAR_ACCESS_LEVEL));
+                final boolean isReadOnly;
+                switch (accessLevel) {
+                    case Calendars.CAL_ACCESS_OWNER:
+                    case Calendars.CAL_ACCESS_EDITOR:
+                    case Calendars.CAL_ACCESS_CONTRIBUTOR:
+                    case Calendars.CAL_ACCESS_ROOT:
+                        isReadOnly = false;
+                        break;
+                    default:
+                        isReadOnly = true;
+                        break;
+                }
+                Calendar calendar = new Calendar(calenderId, displayName, accountName, ownerName, isReadOnly);
                 calendarList.add(calendar);
             }
         } catch (Exception e) {

--- a/android/src/main/java/com/fantastic/manage_calendar_events/models/Calendar.java
+++ b/android/src/main/java/com/fantastic/manage_calendar_events/models/Calendar.java
@@ -11,12 +11,15 @@ public final class Calendar {
   private final String accountName;
   @SerializedName("ownerName")
   private final String ownerName;
+  @SerializedName("isReadOnly")
+  private final boolean isReadOnly;
 
-  public Calendar(String id, String name, String accountName, String ownerName) {
+  public Calendar(String id, String name, String accountName, String ownerName, boolean isReadOnly) {
     this.id = id;
     this.name = name;
-    this.accountName = name;
-    this.ownerName = name;
+    this.accountName = accountName;
+    this.ownerName = ownerName;
+    this.isReadOnly = isReadOnly;
   }
 
   public String getId() {
@@ -35,10 +38,17 @@ public final class Calendar {
     return ownerName;
   }
 
+  public Boolean getIsReadOnly() {
+    return isReadOnly;
+  }
+
   @Override
   public String toString() {
     return new StringBuffer().append(id).append("-").append(name).append("-").append(accountName)
         .append("-")
-        .append(ownerName).toString();
+        .append(ownerName)
+        .append("-")
+        .append(isReadOnly)
+        .toString();
   }
 }

--- a/example/lib/screens/event_details.dart
+++ b/example/lib/screens/event_details.dart
@@ -149,7 +149,7 @@ class _EventDetailsState extends State<EventDetails> {
   _addAttendee(String eventId) async {
     var number = Random().nextInt(100);
     var newAttendee = Attendee(
-        emailAddress: 'attendee$number@gmail.com', name: 'Attendee$number');
+        emailAddress: 'attendee$number@example.com', name: 'Attendee$number');
     await widget.calendarPlugin
         .addAttendees(eventId: eventId, newAttendees: [newAttendee]);
   }

--- a/example/lib/screens/event_list.dart
+++ b/example/lib/screens/event_list.dart
@@ -72,7 +72,7 @@ class _EventListState extends State<EventList> {
                   ),
                 ),
                 child: ListTile(
-                  title: Text(event.title!),
+                  title: Text(event.title ?? ''),
                   subtitle: Text(event.startDate!.toIso8601String()),
                   onTap: () {
                     Navigator.push(

--- a/example/lib/screens/event_list.dart
+++ b/example/lib/screens/event_list.dart
@@ -140,8 +140,8 @@ class _EventListState extends State<EventList> {
       url: 'https://www.google.com',
       attendees: Attendees(
         attendees: [
-          Attendee(emailAddress: 'test1@gmail.com', name: 'Test1'),
-          Attendee(emailAddress: 'test2@gmail.com', name: 'Test2'),
+          Attendee(emailAddress: 'test1@example.com', name: 'Test1'),
+          Attendee(emailAddress: 'test2@example.com', name: 'Test2'),
         ],
       ),
     );
@@ -167,7 +167,7 @@ class _EventListState extends State<EventList> {
     event.description = 'Test description is updated now';
     event.attendees = Attendees(
       attendees: [
-        Attendee(emailAddress: 'updatetest@gmail.com', name: 'Update Test'),
+        Attendee(emailAddress: 'updatetest@example.com', name: 'Update Test'),
       ],
     );
     _myPlugin

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: manage_calendar_events
 description: A flutter plugin which will help you to add, edit and remove the events (with reminders) from your (Android and ios) calendars
-version: 2.0.1
+version: 2.0.2
 homepage: https://github.com/lakshmanaprabhu/manage_calendar_events
 
 environment:


### PR DESCRIPTION
Fixes part of FLTR-6108.

- `getCalendars()` of Android doesn't return the correct `accountName` and `ownerName`. Also, I noticed that isReadOnly should be returned for fixing FLTR-6758. So added it.
- I unintentionally sent lots of spam emails to `test1@gmail.com` etc. because the example includes those real addresses so I changed them to `...@example.com`.

# Screenshots

Please note that After and Before have different code filtering the list elements:

| Before | After |
| - | - |
| ![Screen Shot 2022-01-12 at 6 09 57 pm](https://user-images.githubusercontent.com/1333214/149090572-2c3aea5b-2a3b-4f56-b689-7b6c1ae0b2fd.png) | ![Screen Shot 2022-01-12 at 6 49 06 pm](https://user-images.githubusercontent.com/1333214/149090608-9168e11f-5309-4a09-b71b-4da66fc34a2a.png)|