### PR TITLE
FLTR-8124: Fixed an issue that getCalendars return empty.

### DIFF
--- a/ios/Classes/SwiftManageCalendarEventsPlugin.swift
+++ b/ios/Classes/SwiftManageCalendarEventsPlugin.swift
@@ -7,7 +7,7 @@ extension Date {
 }
 
 public class SwiftManageCalendarEventsPlugin: NSObject, FlutterPlugin {
-    let eventStore = EKEventStore()
+    var eventStore = EKEventStore()
 
     struct Calendar: Codable {
         let id: String
@@ -165,8 +165,11 @@ public class SwiftManageCalendarEventsPlugin: NSObject, FlutterPlugin {
     }
 
     private func requestPermissions() {
-        eventStore.requestAccess(to: .event, completion: {
+        eventStore.requestAccess(to: .event, completion: { [weak self]
             (accessGranted: Bool, error: Error?) in
+            if accessGranted, let weakSelf = self {
+                weakSelf.eventStore =  EKEventStore()
+            }
             print("Access Granted")
         })
     }

--- a/ios/Classes/SwiftManageCalendarEventsPlugin.swift
+++ b/ios/Classes/SwiftManageCalendarEventsPlugin.swift
@@ -167,8 +167,8 @@ public class SwiftManageCalendarEventsPlugin: NSObject, FlutterPlugin {
     private func requestPermissions() {
         eventStore.requestAccess(to: .event, completion: { [weak self]
             (accessGranted: Bool, error: Error?) in
-            if accessGranted, let weakSelf = self {
-                weakSelf.eventStore =  EKEventStore()
+            if accessGranted, let self = self {
+                self.eventStore =  EKEventStore()
             }
             print("Access Granted")
         })


### PR DESCRIPTION
Previously on iOS, there's an issue that after user granted calendar permission for the first time, this plugin returns empty calendars.

This PR addresses this issue by resetting the `EKEventStore` after permission is granted.